### PR TITLE
feat: ataque automático do inimigo após ação do jogador

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,12 +31,6 @@
             ></div>
           </div>
           <strong class="name mb-2 block">--</strong>
-          <button
-            class="attackButton rounded bg-red-900 px-4 py-1 text-white"
-            aria-label="Botão de ataque do inimigo"
-          >
-            Atacar
-          </button>
         </div>
       </div>
 

--- a/src/scripts/classes.js
+++ b/src/scripts/classes.js
@@ -87,7 +87,7 @@ export class Stage {
     this.renderCharacter(this.enemy, this.enemyElement);
   }
 
-  doAttack(attacker, defender) {
+  calculateDamage(attacker, defender) {
     if (!attacker.isAlive() || !defender.isAlive()) {
       this.battleLog.addMessage(
         'Ataque inválido. Um dos personagens já foi derrotado.'
@@ -107,6 +107,11 @@ export class Stage {
       this.battleLog.addMessage(
         `${attacker.name} causou ${damage.toFixed(1)} de dano em ${defender.name}.`
       );
+      if (defender.life <= 0) {
+        this.battleLog.addMessage(
+          `${attacker.name} derrotou ${defender.name}.`
+        );
+      }
     } else {
       this.battleLog.addMessage(`${defender.name} defendeu com sucesso!`);
     }

--- a/src/scripts/scripts.js
+++ b/src/scripts/scripts.js
@@ -1,7 +1,7 @@
-import { Knight, LittleEnemy, Stage } from './index.js';
+import { Knight, BigEnemy, Stage } from './index.js';
 
 const player = new Knight('Pedro');
-const enemy = new LittleEnemy();
+const enemy = new BigEnemy();
 const battleLog = createBattleLog(document.querySelector('.log'));
 
 const stage = new Stage(
@@ -13,12 +13,19 @@ const stage = new Stage(
 );
 
 function setupControls(stage, player, enemy) {
-  document
-    .querySelector('#player .attackButton')
-    .addEventListener('click', () => stage.doAttack(player, enemy));
-  document
-    .querySelector('#enemy .attackButton')
-    .addEventListener('click', () => stage.doAttack(enemy, player));
+  const playerAttackButton = document.querySelector('#player .attackButton');
+
+  playerAttackButton.addEventListener('click', () => {
+    if (playerAttackButton.disabled) return;
+
+    playerAttackButton.disabled = true;
+    stage.calculateDamage(player, enemy);
+
+    setTimeout(() => {
+      stage.calculateDamage(enemy, player);
+      playerAttackButton.disabled = false;
+    }, 1000);
+  });
 }
 
 function createBattleLog(listElement) {


### PR DESCRIPTION
### Alterações realizadas:

- Remove o botão de ataque do inimigo da interface
- Implementa ataque automático do inimigo logo após o jogador atacar
- Adiciona `setTimeout` de 1000ms para simular turno e ritmo
- Desativa o botão do jogador durante o ataque do inimigo para evitar cliques múltiplos

### Motivo:

Essa funcionalidade melhora a fluidez do combate e aproxima o jogo de um sistema baseado em turnos mais automatizado e responsivo.
